### PR TITLE
Ready for JDK11, JUnit5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,2 @@
 language: java
-jdk: oraclejdk8
+jdk: openjdk11

--- a/pom.xml
+++ b/pom.xml
@@ -73,9 +73,15 @@
     </dependency>
 
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>4.12</version>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <version>5.3.1</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <version>5.3.1</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -135,6 +141,12 @@
               <addMavenDescriptor>false</addMavenDescriptor>
             </archive>
           </configuration>
+        </plugin>
+
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <version>2.22.1</version>
         </plugin>
 
         <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,6 @@
     <system>github</system>
   </issueManagement>
 
-
   <distributionManagement>
     <snapshotRepository>
       <id>ossrh</id>
@@ -55,15 +54,16 @@
     </snapshotRepository>
   </distributionManagement>
 
-
   <modules>
     <module>propertly.core</module>
     <module>propertly.serialization</module>
   </modules>
 
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
 
   <dependencies>
-
     <dependency>
       <groupId>org.jetbrains</groupId>
       <artifactId>annotations</artifactId>
@@ -78,54 +78,16 @@
       <version>4.12</version>
       <scope>test</scope>
     </dependency>
-
   </dependencies>
 
 
   <build>
-    <plugins>
-
-      <plugin>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.2</version>
-        <configuration>
-          <source>1.8</source>
-          <target>1.8</target>
-        </configuration>
-      </plugin>
-
-      <plugin>
-        <artifactId>maven-jar-plugin</artifactId>
-        <version>2.5</version>
-        <configuration>
-          <useDefaultManifestFile>true</useDefaultManifestFile>
-          <archive>
-            <manifest>
-              <useUniqueVersions>true</useUniqueVersions>
-              <addClasspath>true</addClasspath>
-              <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
-              <addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
-            </manifest>
-            <addMavenDescriptor>false</addMavenDescriptor>
-          </archive>
-        </configuration>
-      </plugin>
-
-      <plugin>
-        <artifactId>maven-install-plugin</artifactId>
-        <version>2.5.2</version>
-      </plugin>
-
-    </plugins>
-
-
     <pluginManagement>
       <plugins>
-
         <plugin>
           <groupId>org.apache.felix</groupId>
           <artifactId>maven-bundle-plugin</artifactId>
-          <version>2.5.3</version>
+          <version>4.1.0</version>
           <extensions>true</extensions>
           <configuration>
             <instructions>
@@ -134,69 +96,123 @@
               <Bundle-Version>${project.version}</Bundle-Version>
             </instructions>
           </configuration>
-          <executions>
-            <execution>
-              <id>bundle-manifest</id>
-              <phase>process-classes</phase>
-              <goals>
-                <goal>manifest</goal>
-              </goals>
-            </execution>
-          </executions>
         </plugin>
 
         <plugin>
           <artifactId>maven-source-plugin</artifactId>
-          <version>2.4</version>
+          <version>3.0.1</version>
         </plugin>
 
         <plugin>
           <artifactId>maven-javadoc-plugin</artifactId>
-          <version>2.10.3</version>
+          <version>3.0.1</version>
           <configuration>
+            <failOnError>false</failOnError>
             <additionalparam>-Xdoclint:none</additionalparam>
           </configuration>
         </plugin>
 
+        <plugin>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>3.8.0</version>
+          <configuration>
+            <source>11</source>
+            <target>11</target>
+          </configuration>
+        </plugin>
+
+        <plugin>
+          <artifactId>maven-jar-plugin</artifactId>
+          <version>3.1.0</version>
+          <configuration>
+            <archive>
+              <manifest>
+                <useUniqueVersions>true</useUniqueVersions>
+                <addClasspath>true</addClasspath>
+                <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+                <addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
+              </manifest>
+              <addMavenDescriptor>false</addMavenDescriptor>
+            </archive>
+          </configuration>
+        </plugin>
+
+        <plugin>
+          <artifactId>maven-gpg-plugin</artifactId>
+          <version>1.6</version>
+        </plugin>
+
+        <plugin>
+          <groupId>org.sonatype.plugins</groupId>
+          <artifactId>nexus-staging-maven-plugin</artifactId>
+          <version>1.6.8</version>
+          <extensions>true</extensions>
+          <configuration>
+            <serverId>ossrh</serverId>
+            <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+            <autoReleaseAfterClose>true</autoReleaseAfterClose>
+          </configuration>
+        </plugin>
       </plugins>
     </pluginManagement>
 
-  </build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+      </plugin>
 
+      <plugin>
+        <artifactId>maven-jar-plugin</artifactId>
+      </plugin>
+
+      <plugin>
+        <artifactId>maven-source-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>attach-sources</id>
+            <goals>
+              <goal>jar-no-fork</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>attach-javadoc</id>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>bundle-manifest</id>
+            <phase>process-classes</phase>
+            <goals>
+              <goal>manifest</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+
+  </build>
 
   <profiles>
     <profile>
       <id>release</id>
       <build>
         <plugins>
-
-          <plugin>
-            <artifactId>maven-source-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>attach-sources</id>
-                <goals>
-                  <goal>jar-no-fork</goal>
-                </goals>
-              </execution>
-            </executions>
-          </plugin>
-
-          <plugin>
-            <artifactId>maven-javadoc-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>attach-javadoc</id>
-                <goals>
-                  <goal>jar</goal>
-                </goals>
-              </execution>
-            </executions>
-          </plugin>
-
           <plugin>
             <artifactId>maven-gpg-plugin</artifactId>
-            <version>1.6</version>
             <executions>
               <execution>
                 <id>sign-artifacts</id>
@@ -210,24 +226,11 @@
           <plugin>
             <groupId>org.sonatype.plugins</groupId>
             <artifactId>nexus-staging-maven-plugin</artifactId>
-            <version>1.6.5</version>
             <extensions>true</extensions>
-            <configuration>
-              <serverId>ossrh</serverId>
-              <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-              <autoReleaseAfterClose>true</autoReleaseAfterClose>
-            </configuration>
           </plugin>
-
         </plugins>
       </build>
     </profile>
   </profiles>
-
-
-  <properties>
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-  </properties>
-
 
 </project>

--- a/propertly.core/src/test/java/de/adito/propertly/core/api/DynamicPropertiesTest.java
+++ b/propertly.core/src/test/java/de/adito/propertly/core/api/DynamicPropertiesTest.java
@@ -1,13 +1,11 @@
 package de.adito.propertly.core.api;
 
 import de.adito.propertly.core.common.PD;
-import de.adito.propertly.core.spi.IPropertyDescription;
-import de.adito.propertly.core.spi.IPropertyPitProvider;
-import de.adito.propertly.core.spi.extension.AbstractMutablePPP;
-import de.adito.propertly.core.spi.extension.AbstractPPP;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import de.adito.propertly.core.spi.*;
+import de.adito.propertly.core.spi.extension.*;
+import org.junit.jupiter.api.*;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * @author W.Glanzer, 31.03.2017
@@ -16,10 +14,10 @@ public class DynamicPropertiesTest
 {
   private Model._PropertyContainer container;
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception
   {
-    // Datenmodell initialisieren
+    // Initialize Models
     Model rootModel = new Hierarchy<>("rootModel", new Model()).getValue();
     container = rootModel.getProperty(Model.myProperty).setValue(new Model._PropertyContainer());
   }
@@ -29,13 +27,15 @@ public class DynamicPropertiesTest
   {
     PropertyDescription<Model._PropertyContainer, _AbstractProperty> propDesc = new PropertyDescription<>(Model._PropertyContainer.class, _AbstractProperty.class, "property");
     container.addProperty(propDesc).setValue(new Property1());
-    Assert.assertNotNull(container.findProperty(propDesc));
+    assertNotNull(container.findProperty(propDesc));
 
-    try {
+    try
+    {
       container.addProperty(propDesc).setValue(new Property2());
-      Assert.fail(); // We expect an exception - duplicate name
+      fail(); // We expect an exception - duplicate name
     }
-    catch (Exception ignored) {
+    catch (Exception ignored)
+    {
     }
   }
 
@@ -43,16 +43,18 @@ public class DynamicPropertiesTest
   public void test_addPropertyWODescription() throws Exception
   {
     container.addProperty("property1", new Property1());
-    Assert.assertNotNull(container.findProperty("property1"));
+    assertNotNull(container.findProperty("property1"));
 
-    try {
+    try
+    {
       container.addProperty("property1", new Property2());
-      Assert.fail(); // We expect an exception - duplicate name
+      fail(); // We expect an exception - duplicate name
     }
-    catch (Exception ignored) {
+    catch (Exception ignored)
+    {
     }
 
-    Assert.assertEquals(1, container.getProperties().size());
+    assertEquals(1, container.getProperties().size());
   }
 
   public static class Model extends AbstractPPP<IPropertyPitProvider, Model, Object>

--- a/propertly.core/src/test/java/de/adito/propertly/core/api/HierarchyTest.java
+++ b/propertly.core/src/test/java/de/adito/propertly/core/api/HierarchyTest.java
@@ -1,13 +1,10 @@
 package de.adito.propertly.core.api;
 
-import de.adito.propertly.core.spi.IIndexedMutablePropertyPit;
-import de.adito.propertly.core.spi.IProperty;
-import de.adito.propertly.core.spi.IPropertyPitProvider;
+import de.adito.propertly.core.spi.*;
 import de.adito.propertly.core.spi.extension.AbstractIndexedMutablePPP;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.*;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * @author W.Glanzer, 10.10.2016
@@ -17,7 +14,7 @@ public class HierarchyTest
 
   private Hierarchy<MPPP> hierarchy;
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception
   {
     hierarchy = new Hierarchy<>("myHierarchy", new MPPP());
@@ -28,7 +25,7 @@ public class HierarchyTest
   {
     IProperty<IPropertyPitProvider, MPPP> hierProp = hierarchy.getProperty();
     hierProp.rename("myNewName");
-    Assert.assertEquals("myNewName", hierProp.getName());
+    assertEquals("myNewName", hierProp.getName());
   }
 
   @Test
@@ -41,11 +38,11 @@ public class HierarchyTest
     IProperty<MPPP, String> copiedStringProperty = pit.getProperty(stringProp.getDescription());
 
     copiedStringProperty.rename("renamedCopiedStringProp");
-    Assert.assertEquals("stringProp", stringProp.getName());
-    Assert.assertEquals("renamedCopiedStringProp", copiedStringProperty.getName());
+    assertEquals("stringProp", stringProp.getName());
+    assertEquals("renamedCopiedStringProp", copiedStringProperty.getName());
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception
   {
     hierarchy = null;

--- a/propertly.core/src/test/java/de/adito/propertly/core/common/PPPIntrospectorTest.java
+++ b/propertly.core/src/test/java/de/adito/propertly/core/common/PPPIntrospectorTest.java
@@ -1,19 +1,21 @@
 package de.adito.propertly.core.common;
 
-import de.adito.propertly.core.common.exception.InitializationException;
-import de.adito.propertly.core.common.exception.WrongModifiersException;
-import de.adito.propertly.core.spi.IPropertyDescription;
-import de.adito.propertly.core.spi.IPropertyPitProvider;
+import de.adito.propertly.core.common.exception.*;
+import de.adito.propertly.core.spi.*;
 import de.adito.propertly.core.spi.extension.AbstractPPP;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class PPPIntrospectorTest
 {
 
-  @Test(expected = WrongModifiersException.class)
+  @Test
   public void testWrongModifier()
   {
-    PPPIntrospector.get(WRONG_MODIFIER_PIT.class);
+    assertThrows(WrongModifiersException.class, () -> {
+      PPPIntrospector.get(WRONG_MODIFIER_PIT.class);
+    });
   }
 
   private static class WRONG_MODIFIER_PIT extends AbstractPPP<IPropertyPitProvider, WRONG_MODIFIER_PIT, Object>
@@ -21,17 +23,19 @@ public class PPPIntrospectorTest
     IPropertyDescription<WRONG_MODIFIER_PIT, String> PROPERTY = PD.create(WRONG_MODIFIER_PIT.class);
   }
 
-  @Test(expected = InitializationException.class)
+  @Test
   public void testWrongInit() throws Throwable
   {
-    try
-    {
-      PPPIntrospector.get(WRONG_INIT_PIT.class);
-    }
-    catch (ExceptionInInitializerError e)
-    {
-      throw e.getException();
-    }
+    assertThrows(InitializationException.class, () -> {
+      try
+      {
+        PPPIntrospector.get(WRONG_INIT_PIT.class);
+      }
+      catch (ExceptionInInitializerError e)
+      {
+        throw e.getException();
+      }
+    });
   }
 
   private static class WRONG_INIT_PIT extends AbstractPPP<IPropertyPitProvider, WRONG_MODIFIER_PIT, Object>

--- a/propertly.core/src/test/java/de/adito/propertly/test/core/ListenerTest.java
+++ b/propertly.core/src/test/java/de/adito/propertly/test/core/ListenerTest.java
@@ -2,15 +2,14 @@ package de.adito.propertly.test.core;
 
 import de.adito.propertly.core.api.Hierarchy;
 import de.adito.propertly.core.common.PropertyPitEventAdapter;
-import de.adito.propertly.core.spi.IPropertyDescription;
-import de.adito.propertly.core.spi.IPropertyPitEventListener;
-import de.adito.propertly.core.spi.IPropertyPitProvider;
+import de.adito.propertly.core.spi.*;
 import de.adito.propertly.core.spi.extension.AbstractMutablePPP;
 import org.jetbrains.annotations.NotNull;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * @author j.boesl, 13.03.18
@@ -23,12 +22,12 @@ public class ListenerTest
   public void test()
   {
     PPP ppp = new Hierarchy<>("", new PPP()).getValue();
-    pel = new PropertyPitEventAdapter<PPP, Object>()
+    pel = new PropertyPitEventAdapter<>()
     {
       @Override
       public void propertyAdded(@NotNull PPP pSource, @NotNull IPropertyDescription<PPP, Object> pPropertyDescription, @NotNull Set<Object> pAttributes)
       {
-        Assert.fail();
+        fail();
       }
     };
     ppp.addWeakListener(pel);

--- a/propertly.core/src/test/java/de/adito/propertly/test/core/PropertyTest.java
+++ b/propertly.core/src/test/java/de/adito/propertly/test/core/PropertyTest.java
@@ -1,22 +1,18 @@
 package de.adito.propertly.test.core;
 
 import de.adito.propertly.core.api.Hierarchy;
-import de.adito.propertly.core.common.PropertlyDebug;
-import de.adito.propertly.core.common.PropertyPitEventAdapter;
+import de.adito.propertly.core.common.*;
 import de.adito.propertly.core.common.exception.InaccessibleException;
 import de.adito.propertly.core.spi.*;
-import de.adito.propertly.test.core.impl.ColoredPitProvider;
-import de.adito.propertly.test.core.impl.PropertyTestChildren;
-import de.adito.propertly.test.core.impl.TProperty;
-import de.adito.propertly.test.core.impl.VerifyingHierarchy;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
-import org.junit.Assert;
-import org.junit.Test;
+import de.adito.propertly.test.core.impl.*;
+import org.jetbrains.annotations.*;
+import org.junit.jupiter.api.Test;
 
 import java.awt.*;
 import java.util.Set;
 import java.util.function.Consumer;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * @author PaL
@@ -154,7 +150,7 @@ public class PropertyTest
     {
       ex = e;
     }
-    Assert.assertNotNull(ex);
+    assertNotNull(ex);
 
 
     String expected = "hierarchy propertyValueWillBeChanged: null, IndexedMutablePropertyPit, CHILD, property(CHILD, PropertyTestChildren, null), []\n" +
@@ -216,7 +212,7 @@ public class PropertyTest
         "tProperty property: property(HEIGHT, Integer, null)\n" +
         "tProperty property: property(DESCRIPTION, String, null)";
 
-    Assert.assertEquals(expected,
+    assertEquals(expected,
                         resultStringBuild.toString());
 
     expected = "/root\n" +
@@ -240,10 +236,10 @@ public class PropertyTest
         "\t HEIGHT : null\n" +
         "\t DESCRIPTION : null\n";
 
-    Assert.assertEquals(expected,
+    assertEquals(expected,
                         PropertlyDebug.toTreeString(hierarchy));
 
-    Assert.assertEquals(expected,
+    assertEquals(expected,
                         PropertlyDebug.toTreeString(sourceHierarchy));
   }
 
@@ -298,7 +294,7 @@ public class PropertyTest
 
 
     pit.setValue(ColoredPitProvider.DEFAULT_COLOR, Color.MAGENTA);
-    Assert.assertEquals(pit.getValue(ColoredPitProvider.DEFAULT_COLOR), Color.MAGENTA);
+    assertEquals(pit.getValue(ColoredPitProvider.DEFAULT_COLOR), Color.MAGENTA);
 
 
     InaccessibleException ex = null;
@@ -310,21 +306,21 @@ public class PropertyTest
     {
       ex = e;
     }
-    Assert.assertNotNull(ex);
+    assertNotNull(ex);
     ex = null;
-    Assert.assertEquals(pit.getValue(ColoredPitProvider.READ_ONLY_COLOR), null);
+    assertEquals(pit.getValue(ColoredPitProvider.READ_ONLY_COLOR), null);
 
 
     pit.setValue(ColoredPitProvider.WRITE_ONLE_COLOR, Color.YELLOW);
     try
     {
-      Assert.assertEquals(pit.getValue(ColoredPitProvider.WRITE_ONLE_COLOR), null);
+      assertEquals(pit.getValue(ColoredPitProvider.WRITE_ONLE_COLOR), null);
     }
     catch (InaccessibleException e)
     {
       ex = e;
     }
-    Assert.assertNotNull(ex);
+    assertNotNull(ex);
     ex = null;
 
 
@@ -336,17 +332,17 @@ public class PropertyTest
     {
       ex = e;
     }
-    Assert.assertNotNull(ex);
+    assertNotNull(ex);
     ex = null;
     try
     {
-      Assert.assertEquals(pit.getValue(ColoredPitProvider.INACCESSIBLE_COLOR), null);
+      assertEquals(pit.getValue(ColoredPitProvider.INACCESSIBLE_COLOR), null);
     }
     catch (InaccessibleException e)
     {
       ex = e;
     }
-    Assert.assertNotNull(ex);
+    assertNotNull(ex);
   }
 
 }

--- a/propertly.core/src/test/java/de/adito/propertly/test/core/SimpleMutableTest.java
+++ b/propertly.core/src/test/java/de/adito/propertly/test/core/SimpleMutableTest.java
@@ -1,21 +1,17 @@
 package de.adito.propertly.test.core;
 
-import de.adito.propertly.core.api.Hierarchy;
-import de.adito.propertly.core.api.PropertyDescription;
+import de.adito.propertly.core.api.*;
 import de.adito.propertly.core.common.PD;
-import de.adito.propertly.core.spi.IProperty;
-import de.adito.propertly.core.spi.IPropertyDescription;
-import de.adito.propertly.core.spi.IPropertyPitProvider;
+import de.adito.propertly.core.spi.*;
 import de.adito.propertly.core.spi.extension.AbstractIndexedMutablePPP;
 import de.adito.propertly.test.core.impl.DynamicTestPropertyPitProvider;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.awt.*;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Comparator;
+import java.util.*;
 import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * @author j.boesl, 02.12.14
@@ -56,14 +52,14 @@ public class SimpleMutableTest
     property.setValue(Color.black);
     propertyList.add(3, property);
 
-    Assert.assertEquals(propertyList, root.getProperties());
+    assertEquals(propertyList, root.getProperties());
 
 
     Comparator<IProperty<DynamicTestPropertyPitProvider, Color>> comparator = Comparator.comparing(IProperty::getName);
     propertyList.sort(comparator);
     root.reorder(comparator);
 
-    Assert.assertEquals(propertyList, root.getProperties());
+    assertEquals(propertyList, root.getProperties());
 
 
     propertyList.removeIf(
@@ -71,7 +67,7 @@ public class SimpleMutableTest
     root.removeProperty(pinkDescription);
     root.removeProperty(blackDescription);
 
-    Assert.assertEquals(propertyList, root.getProperties());
+    assertEquals(propertyList, root.getProperties());
   }
 
   @Test
@@ -82,8 +78,8 @@ public class SimpleMutableTest
     IProperty<_PPP, String> fixedProperty = pit.getProperty(_PPP.fixedProperty);
     IProperty<_PPP, String> dynamicProperty = pit.addProperty("DynamicProperty");
 
-    Assert.assertEquals(_PPP.class, fixedProperty.getDescription().getSourceType());
-    Assert.assertEquals(_PPP.class, dynamicProperty.getDescription().getSourceType());
+    assertEquals(_PPP.class, fixedProperty.getDescription().getSourceType());
+    assertEquals(_PPP.class, dynamicProperty.getDescription().getSourceType());
   }
 
   public static class _PPP extends AbstractIndexedMutablePPP<IPropertyPitProvider, _PPP, Object>

--- a/propertly.serialization/pom.xml
+++ b/propertly.serialization/pom.xml
@@ -16,21 +16,20 @@
     <dependency>
       <groupId>de.adito.propertly</groupId>
       <artifactId>propertly.core</artifactId>
-      <version>0.4.2</version>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>de.adito.propertly</groupId>
+      <artifactId>propertly.core</artifactId>
+      <version>${project.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>de.adito.picoservice</groupId>
       <artifactId>picoservice</artifactId>
-      <version>1.1.0</version>
-    </dependency>
-
-    <dependency>
-      <groupId>de.adito.propertly</groupId>
-      <artifactId>propertly.core</artifactId>
-      <version>0.4.2</version>
-      <type>test-jar</type>
-      <scope>test</scope>
+      <version>1.1.2</version>
     </dependency>
   </dependencies>
 

--- a/propertly.serialization/src/test/java/de/adito/propertly/serialization/SerializationTest.java
+++ b/propertly.serialization/src/test/java/de/adito/propertly/serialization/SerializationTest.java
@@ -2,23 +2,20 @@ package de.adito.propertly.serialization;
 
 import de.adito.propertly.core.api.Hierarchy;
 import de.adito.propertly.core.common.PropertlyDebug;
-import de.adito.propertly.core.spi.IHierarchy;
-import de.adito.propertly.core.spi.IPropertyPitProvider;
+import de.adito.propertly.core.spi.*;
 import de.adito.propertly.serialization.converter.ConverterRegistry;
-import de.adito.propertly.serialization.converter.impl.EnumStringConverter;
-import de.adito.propertly.serialization.converter.impl.TypePPPStringConverter;
+import de.adito.propertly.serialization.converter.impl.*;
 import de.adito.propertly.serialization.xml.XMLSerializationProvider;
-import de.adito.propertly.test.core.impl.PropertyTestChildren;
-import de.adito.propertly.test.core.impl.TProperty;
-import de.adito.propertly.test.core.impl.VerifyingHierarchy;
-import org.junit.Assert;
-import org.junit.Test;
+import de.adito.propertly.test.core.impl.*;
+import org.junit.jupiter.api.Test;
 import org.w3c.dom.Document;
 
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.transform.TransformerException;
 import java.awt.*;
 import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * @author j.boesl, 27.02.15
@@ -47,7 +44,7 @@ public class SerializationTest
     Map<String, Object> serialize = mapSerializer.serialize(hierarchy);
     IPropertyPitProvider deserialize = mapSerializer.deserialize(serialize);
 
-    Assert.assertEquals(PropertlyDebug.toTreeString(tProperty),
+    assertEquals(PropertlyDebug.toTreeString(tProperty),
                         PropertlyDebug.toTreeString(deserialize));
 
 
@@ -55,7 +52,7 @@ public class SerializationTest
     Document document = xmlSerializer.serialize(hierarchy);
     deserialize = xmlSerializer.deserialize(document);
 
-    Assert.assertEquals(PropertlyDebug.toTreeString(tProperty),
+    assertEquals(PropertlyDebug.toTreeString(tProperty),
                         PropertlyDebug.toTreeString(deserialize));
   }
 


### PR DESCRIPTION
Changes:
* Attach Sources and JavaDoc on every build, to prevent deploying snapshots without them
* Updated Travis to compile with OpenJDK11
* Updated JUnit to use latest JUnit5
* Updated PicoServices to version "1.1.2"
* Maven Plugin Updates:
  * "maven-bundle-plugin" -> "4.1.0"
  * "maven-source-plugin" -> "3.0.1"
  * "maven-javadoc-plugin" -> "3.0.1"
  * "maven-compiler-plugin" -> "3.8.0"
  * "nexus-staging-maven-plugin" -> "1.6.8"