### PR TITLE
Created new UpdateableDelegatingNode

### DIFF
--- a/propertly.core/src/main/java/de/adito/propertly/core/api/DelegatingNode.java
+++ b/propertly.core/src/main/java/de/adito/propertly/core/api/DelegatingNode.java
@@ -2,17 +2,11 @@ package de.adito.propertly.core.api;
 
 import de.adito.propertly.core.common.PropertlyUtility;
 import de.adito.propertly.core.common.exception.PropertlyRenameException;
-import de.adito.propertly.core.spi.IMutablePropertyPitProvider;
-import de.adito.propertly.core.spi.IProperty;
-import de.adito.propertly.core.spi.IPropertyDescription;
-import de.adito.propertly.core.spi.IPropertyPitProvider;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import de.adito.propertly.core.spi.*;
+import org.jetbrains.annotations.*;
 
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
+import java.util.function.*;
 
 /**
  * @author PaL
@@ -39,12 +33,12 @@ public class DelegatingNode extends AbstractNode
   {
     super(pHierarchy, pParent, pPropertyDescription, pDynamic);
     delegate = pDelegate;
-    _alignToDelegate();
+    alignToDelegate();
   }
 
-  private void _alignToDelegate()
+  protected void alignToDelegate()
   {
-    Object value = delegate.getValue();
+    Object value = executeReadOnDelegate(INode::getValue);
     if (value instanceof IPropertyPitProvider && pitProvider == null)
     {
       IPropertyPitProvider ppp = (IPropertyPitProvider) value;
@@ -55,7 +49,7 @@ public class DelegatingNode extends AbstractNode
     else if (value == null)
       pitProvider = null;
 
-    List<INode> delegateChildren = delegate.getChildren();
+    List<INode> delegateChildren = executeReadOnDelegate(INode::getChildren);
     if (delegateChildren != null)
     {
       // create children
@@ -108,9 +102,13 @@ public class DelegatingNode extends AbstractNode
     Object oldValue = getValueInternal();
     List<Runnable> onFinish = new ArrayList<>();
     fireValueWillBeChange(oldValue, pValue, onFinish::add, pAttributes);
-    delegate.setValue(pValue, pAttributes);
-    clearListeners();
-    _alignToDelegate();
+
+    executeWriteOnDelegate(pDelegate -> {
+      pDelegate.setValue(pValue, pAttributes);
+      clearListeners();
+    });
+
+    alignToDelegate();
     Object newValue = getValueInternal();
     fireValueChange(oldValue, newValue, pAttributes);
     onFinish.forEach(Runnable::run);
@@ -126,13 +124,13 @@ public class DelegatingNode extends AbstractNode
   @Override
   public boolean canRead()
   {
-    return isValid() && delegate.canRead();
+    return isValid() && executeReadOnDelegate(INode::canRead);
   }
 
   @Override
   public boolean canWrite()
   {
-    return isValid() && delegate.canWrite();
+    return isValid() && executeReadOnDelegate(INode::canWrite);
   }
 
   @Nullable
@@ -165,9 +163,8 @@ public class DelegatingNode extends AbstractNode
     INode node = findNode(pPropertyDescription.getName());
     if (node != null)
       throw new IllegalStateException("name already exists: " + pPropertyDescription);
-
-    INode delegateChild = delegate.addProperty(pIndex, pPropertyDescription, pAttributes);
-    DelegatingNode child = createChild(delegateChild);
+    executeWriteOnDelegate(pDelegate -> pDelegate.addProperty(pIndex, pPropertyDescription, pAttributes));
+    DelegatingNode child = createChild(executeReadOnDelegate(pDelegate -> pDelegate.findNode(pPropertyDescription)));
     if (children == null)
       children = new NodeChildren();
     children.add(pIndex, child);
@@ -191,7 +188,7 @@ public class DelegatingNode extends AbstractNode
       List<Runnable> onFinish = new ArrayList<>();
       fireNodeWillBeRemoved(description, onFinish::add, pAttributes);
       assert children != null;
-      delegate.removeProperty(pPropertyDescription, pAttributes);
+      executeWriteOnDelegate(pDelegate -> pDelegate.removeProperty(pPropertyDescription, pAttributes));
       children.remove(childNode);
       HierarchyHelper.getNode(property).remove();
       fireNodeRemoved(description, pAttributes);
@@ -213,7 +210,7 @@ public class DelegatingNode extends AbstractNode
     IPropertyDescription description = property.getDescription();
     List<Runnable> onFinish = new ArrayList<>();
     fireNodeWillBeRemoved(description, onFinish::add, pAttributes);
-    delegate.removeProperty(pIndex, pAttributes);
+    executeWriteOnDelegate(pDelegate -> pDelegate.removeProperty(pIndex, pAttributes));
     children.remove(pIndex);
     HierarchyHelper.getNode(property).remove();
     fireNodeRemoved(description, pAttributes);
@@ -235,7 +232,7 @@ public class DelegatingNode extends AbstractNode
       List<Runnable> onFinish = new ArrayList<>();
       firePropertyOrderWillBeChanged(onFinish::add, pAttributes);
       children.reorder(pComparator);
-      delegate.reorder(Comparator.<IProperty>comparingInt(p -> children.indexOf(p.getDescription())), pAttributes);
+      executeWriteOnDelegate(pDelegate -> pDelegate.reorder(Comparator.<IProperty>comparingInt(p -> children.indexOf(p.getDescription())), pAttributes));
       firePropertyOrderChanged(pAttributes);
       onFinish.forEach(Runnable::run);
     }
@@ -251,7 +248,7 @@ public class DelegatingNode extends AbstractNode
 
     try
     {
-      delegate.rename(pName, pAttributes);
+      executeWriteOnDelegate(pDelegate -> pDelegate.rename(pName, pAttributes));
 
       String oldName = property.getName();
       DelegatingNode parent = (DelegatingNode) getParent();
@@ -272,28 +269,46 @@ public class DelegatingNode extends AbstractNode
   @Override
   public boolean isValid()
   {
-    return delegate != null && delegate.isValid();
+    return executeReadOnDelegate(INode::isValid) == Boolean.TRUE;
   }
 
   @Override
   public void remove()
   {
     assert delegate != null;
-    delegate.remove();
+    executeWriteOnDelegate(INode::remove);
     if (isValid() && children != null)
     {
       for (INode child : children)
         child.remove();
     }
-    delegate.remove();
+    executeWriteOnDelegate(INode::remove);
     children = null;
     pitProvider = null;
     delegate = null;
     super.remove();
   }
 
+  protected void executeWriteOnDelegate(@NotNull Consumer<INode> pOnDelegate)
+  {
+    pOnDelegate.accept(delegate);
+  }
+
+  protected <T> T executeReadOnDelegate(@NotNull Function<INode, T> pOnDelegate)
+  {
+    if(delegate == null)
+      return null;
+
+    return pOnDelegate.apply(delegate);
+  }
+
   protected Object getValueInternal()
   {
-    return pitProvider == null && delegate != null ? delegate.getValue() : pitProvider;
+    return pitProvider == null && delegate != null ? executeReadOnDelegate(INode::getValue) : pitProvider;
+  }
+
+  protected boolean hasCreatedCopyOfValue()
+  {
+    return pitProvider != null;
   }
 }

--- a/propertly.core/src/main/java/de/adito/propertly/core/api/UpdateableDelegatingNode.java
+++ b/propertly.core/src/main/java/de/adito/propertly/core/api/UpdateableDelegatingNode.java
@@ -1,0 +1,251 @@
+package de.adito.propertly.core.api;
+
+import de.adito.propertly.core.common.PropertyPitEventAdapter;
+import de.adito.propertly.core.common.exception.PropertlyRenameException;
+import de.adito.propertly.core.common.path.PropertyPath;
+import de.adito.propertly.core.spi.*;
+import org.jetbrains.annotations.*;
+
+import java.util.*;
+import java.util.function.Consumer;
+
+/**
+ * @author w.glanzer, 16.06.2021
+ */
+public class UpdateableDelegatingNode extends DelegatingNode
+{
+  private static final String _EVENT_BY_DELEGATINGNODE = "EVENT_BY_UPDATINGDELEGATINGNODE";
+  private _DelegateListener delegateListener;
+  private ThreadLocal<Boolean> writeOnDelegate;
+
+  protected UpdateableDelegatingNode(@NotNull DelegatingHierarchy pHierarchy, @Nullable AbstractNode pParent, @NotNull INode pDelegate)
+  {
+    super(pHierarchy, pParent, pDelegate);
+  }
+
+  protected UpdateableDelegatingNode(@NotNull DelegatingHierarchy pHierarchy, @Nullable AbstractNode pParent,
+                                     @NotNull IPropertyDescription pPropertyDescription, boolean pDynamic, @NotNull INode pDelegate)
+  {
+    super(pHierarchy, pParent, pPropertyDescription, pDynamic, pDelegate);
+  }
+
+  @Override
+  @Nullable
+  public Object setValue(@Nullable Object pValue, @NotNull Set<Object> pAttributes)
+  {
+    Object delegateValue = executeReadOnDelegate(INode::getValue);
+    if ((!hasCreatedCopyOfValue() && delegateValue instanceof IPropertyPitProvider) || (hasCreatedCopyOfValue() && delegateValue == null))
+      alignToDelegate();
+
+    pAttributes = new HashSet<>(pAttributes);
+    pAttributes.add(_EVENT_BY_DELEGATINGNODE);
+    return super.setValue(pValue, pAttributes);
+  }
+
+  @Override
+  public INode addProperty(@Nullable Integer pIndex, @NotNull IPropertyDescription pPropertyDescription, @NotNull Set<Object> pAttributes)
+  {
+    pAttributes = new HashSet<>(pAttributes);
+    pAttributes.add(_EVENT_BY_DELEGATINGNODE);
+    return super.addProperty(pIndex, pPropertyDescription, pAttributes);
+  }
+
+  @Override
+  public boolean removeProperty(@NotNull IPropertyDescription pPropertyDescription, @NotNull Set<Object> pAttributes)
+  {
+    pAttributes = new HashSet<>(pAttributes);
+    pAttributes.add(_EVENT_BY_DELEGATINGNODE);
+    return super.removeProperty(pPropertyDescription, pAttributes);
+  }
+
+  @Override
+  public void removeProperty(int pIndex, @NotNull Set<Object> pAttributes)
+  {
+    pAttributes = new HashSet<>(pAttributes);
+    pAttributes.add(_EVENT_BY_DELEGATINGNODE);
+    super.removeProperty(pIndex, pAttributes);
+  }
+
+  @Override
+  public void reorder(@NotNull Comparator pComparator, @NotNull Set<Object> pAttributes)
+  {
+    pAttributes = new HashSet<>(pAttributes);
+    pAttributes.add(_EVENT_BY_DELEGATINGNODE);
+    super.reorder(pComparator, pAttributes);
+  }
+
+  @Override
+  public void rename(@NotNull String pName, @NotNull Set<Object> pAttributes) throws PropertlyRenameException
+  {
+    pAttributes = new HashSet<>(pAttributes);
+    pAttributes.add(_EVENT_BY_DELEGATINGNODE);
+    super.rename(pName, pAttributes);
+  }
+
+  @Override
+  public void remove()
+  {
+    executeReadOnDelegate(pDelegate -> {
+      if (delegateListener != null && pDelegate != null && pDelegate.isValid())
+        pDelegate.removeListener(delegateListener);
+      return null;
+    });
+
+    delegateListener = null;
+    super.remove();
+    writeOnDelegate = null;
+  }
+
+  @Override
+  protected DelegatingNode createChild(INode pDelegate)
+  {
+    return new UpdateableDelegatingNode(getHierarchy(), this, pDelegate);
+  }
+
+  @Override
+  protected void alignToDelegate()
+  {
+    executeReadOnDelegate(pDelegate -> {
+      if (pDelegate != null && pDelegate.isValid())
+      {
+        if (delegateListener == null)
+          delegateListener = new _DelegateListener();
+        pDelegate.removeListener(delegateListener);
+        pDelegate.addWeakListener(delegateListener);
+      }
+      return null;
+    });
+
+    _runWithoutWriteThrough(super::alignToDelegate);
+  }
+
+  @Override
+  protected void executeWriteOnDelegate(@NotNull Consumer<INode> pOnDelegate)
+  {
+    if (writeOnDelegate == null || writeOnDelegate.get() != Boolean.FALSE)
+      super.executeWriteOnDelegate(pOnDelegate);
+  }
+
+  /**
+   * Executes the given runnable without writing to the underlying delegate
+   *
+   * @param pRunnable Runnable that will be executed
+   */
+  private void _runWithoutWriteThrough(@NotNull Runnable pRunnable)
+  {
+    if (writeOnDelegate == null)
+      writeOnDelegate = new ThreadLocal<>();
+
+    try
+    {
+      writeOnDelegate.set(false);
+      pRunnable.run();
+    }
+    finally
+    {
+      writeOnDelegate.remove();
+    }
+  }
+
+  /**
+   * Listener auf dem Delegate, um Änderungen zu propagieren
+   */
+  private class _DelegateListener extends PropertyPitEventAdapter<IPropertyPitProvider<?, ?, ?>, Object>
+  {
+    @Override
+    public void propertyRemoved(@NotNull IPropertyPitProvider<?, ?, ?> pSource,
+                                @NotNull IPropertyDescription<IPropertyPitProvider<?, ?, ?>, Object> pPropertyDescription,
+                                @NotNull Set<Object> pAttributes)
+    {
+      if (pAttributes.contains(_EVENT_BY_DELEGATINGNODE))
+        return;
+
+      if (!pSource.getPit().getOwnProperty().getDescription().equals(getProperty().getDescription()))
+        throw new IllegalStateException("event fired in wrong listener of property " + new PropertyPath(pSource) +
+                                            " (original: " + new PropertyPath(getProperty()) + ")");
+
+      _runWithoutWriteThrough(() -> removeProperty(pPropertyDescription, pAttributes));
+    }
+
+    @Override
+    public void propertyAdded(@NotNull IPropertyPitProvider<?, ?, ?> pSource,
+                              @NotNull IPropertyDescription<IPropertyPitProvider<?, ?, ?>, Object> pPropertyDescription,
+                              @NotNull Set<Object> pAttributes)
+    {
+      if (pAttributes.contains(_EVENT_BY_DELEGATINGNODE))
+        return;
+
+      if (!pSource.getPit().getOwnProperty().getDescription().equals(getProperty().getDescription()))
+        throw new IllegalStateException("event fired in wrong listener of property " + new PropertyPath(pSource) +
+                                            " (original: " + new PropertyPath(getProperty()) + ")");
+
+      _runWithoutWriteThrough(() -> {
+        Integer index = null;
+        if (pSource instanceof IIndexedMutablePropertyPit<?, ?, ?>)
+          index = ((IIndexedMutablePropertyPit<?, ?, ?>) pSource).indexOf(pPropertyDescription);
+        addProperty(index, pPropertyDescription, pAttributes);
+      });
+    }
+
+    @Override
+    public void propertyOrderChanged(@NotNull IPropertyPitProvider<?, ?, ?> pSource, @NotNull Set<Object> pAttributes)
+    {
+      if (pAttributes.contains(_EVENT_BY_DELEGATINGNODE))
+        return;
+
+      if (!pSource.getPit().getOwnProperty().getDescription().equals(getProperty().getDescription()))
+        throw new IllegalStateException("event fired in wrong listener of property " + new PropertyPath(pSource) +
+                                            " (original: " + new PropertyPath(getProperty()) + ")");
+
+      _runWithoutWriteThrough(() -> executeReadOnDelegate(pDelegate -> {
+        reorder(Comparator.<INode>comparingInt(pNode -> pDelegate.indexOf(pNode.getProperty().getDescription())), pAttributes);
+        return null;
+      }));
+    }
+
+    @Override
+    public void propertyValueWillBeChanged(@NotNull IProperty<IPropertyPitProvider<?, ?, ?>, Object> pProperty, @Nullable Object pOldValue,
+                                           @Nullable Object pNewValue, @NotNull Consumer<Runnable> pOnChanged, @NotNull Set<Object> pAttributes)
+    {
+      if (pAttributes.contains(_EVENT_BY_DELEGATINGNODE))
+        return;
+
+      UpdateableDelegatingNode node = (UpdateableDelegatingNode) findNode(pProperty.getDescription());
+      if (node == null)
+        throw new IllegalStateException("Source property was changed, but could not be found in delegate hierarchy " +
+                                            "(" + new PropertyPath(pProperty) + ")");
+
+      node.fireValueWillBeChange(node.getValue(), pNewValue, pOnChanged, pAttributes);
+    }
+
+    @Override
+    public void propertyValueChanged(@NotNull IProperty<IPropertyPitProvider<?, ?, ?>, Object> pProperty, @Nullable Object pOldValue,
+                                     @Nullable Object pNewValue, @NotNull Set<Object> pAttributes)
+    {
+      if (pAttributes.contains(_EVENT_BY_DELEGATINGNODE))
+        return;
+
+      UpdateableDelegatingNode node = (UpdateableDelegatingNode) findNode(pProperty.getDescription());
+      if (node == null)
+        throw new IllegalStateException("Source property was changed, but could not be found in delegate hierarchy " +
+                                            "(" + new PropertyPath(pProperty) + ")");
+
+      _runWithoutWriteThrough(node::alignToDelegate);
+      node.fireValueChange(pOldValue, node.getValue(), pAttributes);
+    }
+
+    @Override
+    public void propertyNameChanged(@NotNull IProperty<IPropertyPitProvider<?, ?, ?>, Object> pProperty, @NotNull String pOldName,
+                                    @NotNull String pNewName, @NotNull Set<Object> pAttributes)
+    {
+      if (pAttributes.contains(_EVENT_BY_DELEGATINGNODE))
+        return;
+
+      if (!pProperty.getDescription().equals(getProperty().getDescription().copy(pNewName)))
+        throw new IllegalStateException("event fired in wrong listener of property " + new PropertyPath(pProperty) +
+                                            " (original: " + new PropertyPath(getProperty()) + ")");
+
+      _runWithoutWriteThrough(() -> rename(pNewName, pAttributes));
+    }
+  }
+}

--- a/propertly.core/src/test/java/de/adito/propertly/core/api/UpdateableDelegatingNodeTest.java
+++ b/propertly.core/src/test/java/de/adito/propertly/core/api/UpdateableDelegatingNodeTest.java
@@ -1,0 +1,263 @@
+package de.adito.propertly.core.api;
+
+import de.adito.propertly.core.common.PD;
+import de.adito.propertly.core.common.path.PropertyPath;
+import de.adito.propertly.core.spi.*;
+import de.adito.propertly.core.spi.extension.*;
+import org.jetbrains.annotations.*;
+import org.junit.jupiter.api.*;
+
+import java.util.*;
+import java.util.function.Consumer;
+
+/**
+ * @author w.glanzer, 17.06.2021
+ */
+public class UpdateableDelegatingNodeTest
+{
+  private DummyModel sourceModel;
+  private DummyModel updateableModel;
+  private _ReadableListener sourceHierarchyListener;
+  private _ReadableListener updateableHierarchyListener;
+
+  @BeforeEach
+  void setUp()
+  {
+    // prepare hierarchies
+    Hierarchy<DummyModel> sourceHierarchy = new Hierarchy<>("dummy", new DummyModel());
+    Hierarchy<DummyModel> updateableHierarchy = new DelegatingHierarchy<DummyModel>(sourceHierarchy,
+                                                              (pHierarchy, pSourceNode) -> new UpdateableDelegatingNode(pHierarchy, null, pSourceNode))
+    {
+    };
+
+    // prepare models
+    sourceModel = sourceHierarchy.getValue();
+    updateableModel = updateableHierarchy.getValue();
+    Assertions.assertNotNull(sourceModel);
+    Assertions.assertNotNull(updateableModel);
+
+    // add listeners
+    sourceHierarchyListener = new _ReadableListener();
+    updateableHierarchyListener = new _ReadableListener();
+    sourceHierarchy.addWeakListener(sourceHierarchyListener);
+    updateableHierarchy.addWeakListener(updateableHierarchyListener);
+  }
+
+  @Test
+  void test_source_static_change()
+  {
+    sourceModel.getProperty(DummyModel.simpleStringProperty).setValue("simpleStringValue");
+    Assertions.assertEquals(sourceHierarchyListener.asString(), updateableHierarchyListener.asString());
+  }
+
+  @Test
+  void test_source_dynamic_addRemove()
+  {
+    DummyModel.SubModelContainer container = sourceModel.setValue(DummyModel.subModels, new DummyModel.SubModelContainer());
+    Assertions.assertNotNull(container);
+    SubModel subModel = container.addProperty(new SubModel()).getValue();
+    Assertions.assertNotNull(subModel);
+
+    container.removeProperty(subModel.getOwnProperty());
+
+    container.addProperty(new SubModel());
+    container.addProperty(new SubModel());
+
+    Assertions.assertEquals(sourceHierarchyListener.asString(), updateableHierarchyListener.asString());
+  }
+
+  @Test
+  void test_source_dynamic_change()
+  {
+    DummyModel.SubModelContainer container = sourceModel.setValue(DummyModel.subModels, new DummyModel.SubModelContainer());
+    Assertions.assertNotNull(container);
+    SubModel subModel = container.addProperty(new SubModel()).getValue();
+    Assertions.assertNotNull(subModel);
+
+    for(int i = 0; i < 50; i++)
+      subModel.setValue(SubModel.subModelProperty, UUID.randomUUID().toString());
+
+    Assertions.assertEquals(sourceHierarchyListener.asString(), updateableHierarchyListener.asString());
+  }
+
+  @Test
+  void test_source_dynamic_rename()
+  {
+    DummyModel.SubModelContainer container = sourceModel.setValue(DummyModel.subModels, new DummyModel.SubModelContainer());
+    Assertions.assertNotNull(container);
+    SubModel subModel = container.addProperty(new SubModel()).getValue();
+    Assertions.assertNotNull(subModel);
+
+    subModel.getOwnProperty().rename("myNewName");
+
+    Assertions.assertNotNull(new PropertyPath(subModel).find(updateableModel.getPit().getHierarchy()));
+    Assertions.assertEquals(sourceHierarchyListener.asString(), updateableHierarchyListener.asString());
+  }
+
+  @Test
+  void test_delegate_static_writeThrough()
+  {
+    updateableModel.setValue(DummyModel.simpleStringProperty, "setFromUpdateable");
+    Assertions.assertEquals(updateableModel.getValue(DummyModel.simpleStringProperty), sourceModel.getValue(DummyModel.simpleStringProperty));
+    Assertions.assertEquals(updateableHierarchyListener.asString(), sourceHierarchyListener.asString());
+  }
+
+  @Test
+  void test_delegate_dynamic_writeThrough()
+  {
+    DummyModel.SubModelContainer container = updateableModel.setValue(DummyModel.subModels, new DummyModel.SubModelContainer());
+    Assertions.assertNotNull(container);
+    SubModel subModel = container.addProperty(new SubModel()).getValue();
+    Assertions.assertNotNull(subModel);
+    IProperty<SubModel, String> subModelProperty = subModel.getProperty(SubModel.subModelProperty);
+    subModelProperty.setValue("subModel_setFromUpdateable");
+
+    IProperty<?, ?> sourceProperty = new PropertyPath(subModelProperty).find(sourceModel.getPit().getHierarchy());
+    Assertions.assertNotNull(sourceProperty);
+    Assertions.assertEquals(subModelProperty.getValue(), sourceProperty.getValue());
+    Assertions.assertEquals(updateableHierarchyListener.asString(), sourceHierarchyListener.asString());
+  }
+
+  @Test
+  void test_delegate_dynamic_remove()
+  {
+    DummyModel.SubModelContainer container = updateableModel.setValue(DummyModel.subModels, new DummyModel.SubModelContainer());
+    Assertions.assertNotNull(container);
+    SubModel subModel = container.addProperty(new SubModel()).getValue();
+    Assertions.assertNotNull(subModel);
+    container.removeProperty(subModel.getOwnProperty());
+    Assertions.assertEquals(updateableHierarchyListener.asString(), sourceHierarchyListener.asString());
+  }
+
+  public static class DummyModel extends AbstractPPP<IPropertyPitProvider<?, ?, ?>, DummyModel, Object>
+  {
+    public static final IPropertyDescription<DummyModel, String> simpleStringProperty = PD.create(DummyModel.class);
+
+    public static final IPropertyDescription<DummyModel, SubModelContainer> subModels = PD.create(DummyModel.class);
+
+    public static class SubModelContainer extends AbstractMutablePPP<DummyModel, SubModelContainer, SubModel>
+    {
+      public SubModelContainer()
+      {
+        super(SubModel.class);
+      }
+
+      @Override
+      public String toString()
+      {
+        return getClass().getName();
+      }
+    }
+
+    @Override
+    public String toString()
+    {
+      return getClass().getName();
+    }
+  }
+
+  public static class SubModel extends AbstractPPP<DummyModel.SubModelContainer, SubModel, Object>
+  {
+    public static final IPropertyDescription<SubModel, String> subModelProperty = PD.create(SubModel.class);
+
+    @Override
+    public String toString()
+    {
+      return getClass().getName();
+    }
+  }
+
+  private static class _ReadableListener implements IPropertyPitEventListener<IPropertyPitProvider<?, ?, ?>, Object>
+  {
+    private final StringBuilder builder = new StringBuilder();
+
+    @Override
+    public void propertyValueWillBeChanged(@NotNull IProperty<IPropertyPitProvider<?, ?, ?>, Object> pProperty,
+                                           @Nullable Object pOldValue, @Nullable Object pNewValue, @NotNull Consumer<Runnable> pOnChanged,
+                                           @NotNull Set<Object> pAttributes)
+    {
+      builder.append("propertyValueWillBeChanged")
+          .append(" ").append(new PropertyPath(pProperty).asString())
+          .append(" ").append(pOldValue)
+          .append(" ").append(pNewValue)
+          .append('\n');
+    }
+
+    @Override
+    public void propertyValueChanged(@NotNull IProperty<IPropertyPitProvider<?, ?, ?>, Object> pProperty, @Nullable Object pOldValue,
+                                     @Nullable Object pNewValue, @NotNull Set<Object> pAttributes)
+    {
+      builder.append("propertyValueChanged")
+          .append(" ").append(new PropertyPath(pProperty).asString())
+          .append(" ").append(pOldValue)
+          .append(" ").append(pNewValue)
+          .append('\n');
+    }
+
+    @Override
+    public void propertyNameChanged(@NotNull IProperty<IPropertyPitProvider<?, ?, ?>, Object> pProperty, @NotNull String pOldName,
+                                    @NotNull String pNewName, @NotNull Set<Object> pAttributes)
+    {
+      builder.append("propertyNameChanged")
+          .append(" ").append(new PropertyPath(pProperty).asString())
+          .append(" ").append(pOldName)
+          .append(" ").append(pNewName)
+          .append('\n');
+    }
+
+    @Override
+    public void propertyWillBeRemoved(@NotNull IProperty<IPropertyPitProvider<?, ?, ?>, Object> pProperty, @NotNull Consumer<Runnable> pOnRemoved,
+                                      @NotNull Set<Object> pAttributes)
+    {
+      builder.append("propertyWillBeRemoved")
+          .append(" ").append(new PropertyPath(pProperty).asString())
+          .append('\n');
+    }
+
+    @Override
+    public void propertyRemoved(@NotNull IPropertyPitProvider<?, ?, ?> pSource,
+                                @NotNull IPropertyDescription<IPropertyPitProvider<?, ?, ?>, Object> pPropertyDescription,
+                                @NotNull Set<Object> pAttributes)
+    {
+      builder.append("propertyRemoved")
+          .append(" ").append(new PropertyPath(pSource).asString())
+          .append(" ").append(pPropertyDescription.getName())
+          .append('\n');
+    }
+
+    @Override
+    public void propertyAdded(@NotNull IPropertyPitProvider<?, ?, ?> pSource,
+                              @NotNull IPropertyDescription<IPropertyPitProvider<?, ?, ?>, Object> pPropertyDescription,
+                              @NotNull Set<Object> pAttributes)
+    {
+      builder.append("propertyAdded")
+          .append(" ").append(new PropertyPath(pSource).asString())
+          .append(" ").append(pPropertyDescription.getName())
+          .append('\n');
+    }
+
+    @Override
+    public void propertyOrderWillBeChanged(@NotNull IPropertyPitProvider<?, ?, ?> pSource, @NotNull Consumer<Runnable> pOnChanged,
+                                           @NotNull Set<Object> pAttributes)
+    {
+      builder.append("propertyOrderWillBeChanged")
+          .append(" ").append(new PropertyPath(pSource).asString())
+          .append('\n');
+    }
+
+    @Override
+    public void propertyOrderChanged(@NotNull IPropertyPitProvider<?, ?, ?> pSource, @NotNull Set<Object> pAttributes)
+    {
+      builder.append("propertyOrderChanged")
+          .append(" ").append(new PropertyPath(pSource).asString())
+          .append('\n');
+    }
+
+    @NotNull
+    public String asString()
+    {
+      return builder.toString();
+    }
+  }
+
+}


### PR DESCRIPTION
I created a new kind of DelegatingNode to allow propagating events from the underlying delegate.
Therefor it was necessary to modify the original DelegatingNode: All writes / reads have to be separated from each other, so the new UpdateableDelegatingNode is able to "disallow" writes if necessary.

Good to know: The UpdateableDelegatingNode will override its own tree structure, if the underlying delegate changes.

To ensure that the new node works like expected (and fires events in correct order), a new unit test was added too.

This PR implements #9 , so that this issue can be marked as resolved as soon as this PR was approved